### PR TITLE
docs: fix project path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Monorepo containing a React front-end and Node/Express/Sequelize back-end.
 ## Structure
 
 ```
-ai_001/
+ap_002/
  ├ clothing-inspection-backend/   # Express + Sequelize API
  ├ clothing-inspection-frontend/  # React (CRA) web app
  ├ uploads/                       # runtime file uploads (ignored)
@@ -25,7 +25,7 @@ ai_001/
 1. **Clone & install**
    ```bash
    git clone https://github.com/sprjihoon/ap_002.git
-   cd ai_001
+   cd ap_002
    npm install           # root dev-tools (optional)
    ```
 


### PR DESCRIPTION
## Summary
- update repo path to `ap_002` in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68590c5d62248328852846fc1223ec9e