### PR TITLE
Fix failing NPM test scripts

### DIFF
--- a/clothing-inspection-backend/package.json
+++ b/clothing-inspection-backend/package.json
@@ -4,7 +4,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "dev": "nodemon app.js"
+    "dev": "nodemon app.js",
+    "test": "echo \"No backend tests available\" && exit 0"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"No tests available\" && exit 0"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",


### PR DESCRIPTION
## Summary
- disable failing test script in root package.json
- add placeholder test script for backend package

## Testing
- `npm test --silent`
- `cd clothing-inspection-backend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685aa285c1808328b43a8bd1035c8ee8