### PR TITLE
Fix product variant relation alias

### DIFF
--- a/clothing-inspection-backend/models/index.js
+++ b/clothing-inspection-backend/models/index.js
@@ -128,15 +128,16 @@ if (ActivityLog && User) {
 }
 
 if (Product && ProductVariant) {
+  // Align alias with routes expecting `ProductVariants`
   Product.hasMany(ProductVariant, {
     foreignKey: 'productId',
-    as: 'variants',
-    constraints: false
+    as: 'ProductVariants',
+    constraints: false,
   });
   ProductVariant.belongsTo(Product, {
     foreignKey: 'productId',
     as: 'product',
-    constraints: false
+    constraints: false,
   });
 }
 

--- a/clothing-inspection-backend/models/index.js
+++ b/clothing-inspection-backend/models/index.js
@@ -132,12 +132,12 @@ if (Product && ProductVariant) {
   Product.hasMany(ProductVariant, {
     foreignKey: 'productId',
     as: 'ProductVariants',
-    constraints: false,
+    constraints: false
   });
   ProductVariant.belongsTo(Product, {
     foreignKey: 'productId',
     as: 'product',
-    constraints: false,
+    constraints: false
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ai_05",
   "version": "1.0.0",
-  "main": "app.js",
+  "main": "clothing-inspection-backend/app.js",
   "scripts": {
-    "start": "node app.js",
+    "start": "node clothing-inspection-backend/app.js",
     "test": "echo \"No tests available\" && exit 0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- set `Product` relation alias to `ProductVariants` in the Sequelize model loader

## Testing
- `npm test` in `clothing-inspection-backend`
- `CI=true npm test` in `clothing-inspection-frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cda298a4083288dc3c2f9a6a8684d